### PR TITLE
__init__ now takes input rather than __call__

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -30,6 +30,7 @@ pygments_style = 'sphinx'
 html_theme = "sphinx_rtd_theme"
 html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
 htmlhelp_basename = '%sdoc' % project
+autoclass_content = 'both'
 
 latex_documents = [
     ('index', '%s.tex' % project, u'%s Documentation' % project, copyright_holder, 'manual'),
@@ -48,6 +49,9 @@ release = version
 
 
 def autodoc_skip_member(app, what, name, obj, skip, options):
+    if name == '__init__':
+        return False
+
     exclusions = ('__weakref__',  # special-members
                   '__doc__', '__module__', '__dict__',  # undoc-members
                   )

--- a/eater/tests/api/test_http.py
+++ b/eater/tests/api/test_http.py
@@ -8,8 +8,8 @@
 """
 
 import pytest
-import requests_mock
 from requests.structures import CaseInsensitiveDict
+import requests_mock
 from schematics import Model
 from schematics.exceptions import DataError
 from schematics.types import StringType
@@ -39,8 +39,8 @@ def test_get_url_with_request_cls_none():  # pylint: disable=invalid-name
         response_cls = Model
         url = 'http://example.com'
 
-    api = PersonAPI()
-    api.get_url(None)
+    api = PersonAPI(None)
+    assert api.url == 'http://example.com'
 
 
 def test_must_define_response_cls():
@@ -70,8 +70,8 @@ def test_get_request():
         response_cls = Person
         url = 'http://example.com/person'
 
-    api = PersonAPI()
     expected_person = Person(dict(name='John'))
+    api = PersonAPI(name=expected_person.name)
 
     with requests_mock.Mocker() as mock:
         mock.get(
@@ -82,11 +82,12 @@ def test_get_request():
             })
         )
 
-        actual_person = api(name=expected_person.name)
+        actual_person = api()
         assert actual_person == expected_person
 
         # Now check that api can take a model as the first parameter
-        actual_person = api(expected_person)
+        api = PersonAPI(expected_person)
+        actual_person = api()
         assert actual_person == expected_person
 
 
@@ -99,8 +100,8 @@ def test_request_cls_none():
         response_cls = Person
         url = 'http://example.com/person'
 
-    api = PersonAPI()
     expected_person = Person(dict(name='John'))
+    api = PersonAPI(name=expected_person.name)
 
     with requests_mock.Mocker() as mock:
         mock.get(
@@ -111,7 +112,7 @@ def test_request_cls_none():
             })
         )
 
-        actual_person = api(name=expected_person.name)
+        actual_person = api()
         assert actual_person == expected_person
 
 
@@ -124,7 +125,7 @@ def test_data_error_raised():
         response_cls = Person
         url = 'http://example.com/person'
 
-    api = PersonAPI()
+    api = PersonAPI(name='John')
 
     with pytest.raises(DataError):
         with requests_mock.Mocker() as mock:
@@ -135,7 +136,7 @@ def test_data_error_raised():
                     'Content-Type': 'application/json'
                 })
             )
-            api(name='John')
+            api()
 
 
 def test_url_formatting():
@@ -147,17 +148,20 @@ def test_url_formatting():
         response_cls = Person
         url = 'http://example.com/person/{request_model.name}/'
 
-    api = GetPersonAPI()
+    expected_url = 'http://example.com/person/John/'
+
+    api = GetPersonAPI(name='John')
+    assert api.url == expected_url
 
     with requests_mock.Mocker() as mock:
         mock.get(
-            'http://example.com/person/John/',
+            expected_url,
             json={'name': 'John'},
             headers=CaseInsensitiveDict({
                 'Content-Type': 'application/json'
             })
         )
-        response = api(name='John')
+        response = api()
         assert response.name == 'John'
 
 
@@ -170,10 +174,13 @@ def test_get_url():
         response_cls = Person
         url = 'http://example.com/person/'
 
-        def get_url(self, request_model: Person) -> str:
-            return '%s%s/' % (self.url, request_model.name)
+        def get_url(self) -> str:
+            return '%s%s/' % (type(self).url, self.request_model.name)
 
-    api = GetPersonAPI()
+    expected_url = 'http://example.com/person/John/'
+
+    api = GetPersonAPI(name='John')
+    assert api.url == expected_url
 
     with requests_mock.Mocker() as mock:
         mock.get(
@@ -183,5 +190,5 @@ def test_get_url():
                 'Content-Type': 'application/json'
             })
         )
-        response = api(name='John')
+        response = api()
         assert response.name == 'John'


### PR DESCRIPTION
Changed API so that now `__init__` takes arguments for call to create `request_cls` instance rather than `__call__`.